### PR TITLE
feat: Initial commit

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,0 +1,32 @@
+policies:
+  - type: commit
+    spec:
+      headerLength: 89
+      dco: true
+      gpg: false
+      imperative: true
+      maximumOfOneCommit: true
+      requireCommitBody: true
+      conventional:
+        types:
+          - chore
+          - docs
+          - perf
+          - refactor
+          - style
+          - test
+        scopes:
+          - '*'
+  - type: license
+    spec:
+      skipPaths:
+        - .git/
+        - .buildkit/
+      includeSuffixes:
+        - .go
+      excludeSuffixes:
+        - .pb.go
+      header: |
+        /* This Source Code Form is subject to the terms of the Mozilla Public
+         * License, v. 2.0. If a copy of the MPL was not distributed with this
+         * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,96 @@
+---
+kind: pipeline
+name: default
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: buildkit
+  detach: true
+  image: moby/buildkit:v0.6.0
+  privileged: true
+  commands:
+    - buildkitd --addr unix:///var/run/buildkit/buildkitd.sock --allow-insecure-entitlement security.insecure
+  volumes:
+  - name: dockersock
+    path: /var/run
+  when:
+    event:
+      - ""
+
+- name: build
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make protoc-gen-proxy
+  environment:
+    BINDIR: /usr/local/bin
+    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - buildkit
+
+- name: push
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make gitmeta
+  - make login
+  - make push
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  when:
+    event:
+      exclude:
+      - pull_request
+  depends_on:
+  - build
+
+services:
+- name: docker
+  image: docker:19.03-dind
+  entrypoint:
+  - dockerd
+  command:
+  - --dns=8.8.8.8
+  - --dns=8.8.4.4
+  - --mtu=1440
+  - --log-level=error
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+
+volumes:
+- name: dockersock
+  temp: {}
+- name: dev
+  host:
+    path: /dev
+- name: tmp
+  temp: {}
+
+node:
+  node-role.kubernetes.io/ci: ""

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+# syntax = docker/dockerfile-upstream:1.1.2-experimental
+
+# Meta args applied to stage base names.
+
+ARG TOOLS
+ARG GO_VERSION
+
+# The tools target provides base toolchain for the build.
+
+FROM $TOOLS AS tools
+ENV PATH /toolchain/bin:/toolchain/go/bin
+RUN ["/toolchain/bin/mkdir", "-p", "/bin", "/tmp"]
+RUN ["/toolchain/bin/ln", "-svf", "/toolchain/bin/bash", "/bin/sh"]
+RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | \
+    bash -s -- -b /toolchain/bin v1.20.0
+RUN cd $(mktemp -d) \
+    && go mod init tmp \
+    && go get mvdan.cc/gofumpt/gofumports \
+    && mv /go/bin/gofumports /toolchain/go/bin/gofumports
+RUN curl -sfL https://github.com/uber/prototool/releases/download/v1.8.0/prototool-Linux-x86_64.tar.gz | \
+    tar -xz --strip-components=2 -C /toolchain/bin prototool/bin/prototool
+
+# The build target creates a container that will be used to build the source
+# code.
+
+FROM scratch AS build
+COPY --from=tools / /
+SHELL ["/toolchain/bin/bash", "-c"]
+ENV PATH /toolchain/bin:/toolchain/go/bin
+ENV GO111MODULE on
+ENV GOPROXY https://proxy.golang.org
+ENV CGO_ENABLED 0
+WORKDIR /src
+
+FROM build AS base
+COPY ./go.mod ./
+COPY ./go.sum ./
+RUN go mod download
+RUN go mod verify
+COPY ./pkg ./pkg
+COPY ./main.go ./main.go
+RUN go list -mod=readonly all >/dev/null
+RUN ! go mod tidy -v 2>&1 | grep .
+
+FROM base AS protoc-gen-proxy-build
+ARG SHA
+ARG TAG
+ARG VERSION_PKG="github.com/talos-systems/talos/pkg/version"
+WORKDIR /src
+RUN --mount=type=cache,target=/.cache/go-build \
+    go build -ldflags \
+    "-s -w -X ${VERSION_PKG}.Name=Server -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" \
+    -o /protoc-gen-proxy
+RUN chmod +x /protoc-gen-proxy
+
+FROM scratch AS protoc-gen-proxy
+COPY --from=protoc-gen-proxy-build /protoc-gen-proxy /protoc-gen-proxy
+
+#FROM base AS unit-tests-runner
+#RUN unlink /etc/ssl
+#ARG TESTPKGS
+#RUN --security=insecure --mount=type=cache,id=testspace,target=/tmp --mount=type=cache,target=/.cache/go-build \
+#    go test -v
+#
+#FROM scratch AS unit-tests
+#COPY --from=unit-tests-runner /src/coverage.txt /coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,115 @@
+TOOLS ?= autonomy/toolchain:latest
+
+# TODO(andrewrynhard): Move this logic to a shell script.
+BUILDKIT_VERSION ?= v0.6.0
+GO_VERSION ?= 1.12
+BUILDKIT_IMAGE ?= moby/buildkit:$(BUILDKIT_VERSION)
+BUILDKIT_HOST ?= tcp://0.0.0.0:1234
+BUILDKIT_CONTAINER_NAME ?= talos-buildkit
+BUILDKIT_CONTAINER_STOPPED := $(shell docker ps --filter name=$(BUILDKIT_CONTAINER_NAME) --filter status=exited --format='{{.Names}}' 2>/dev/null)
+BUILDKIT_CONTAINER_RUNNING := $(shell docker ps --filter name=$(BUILDKIT_CONTAINER_NAME) --filter status=running --format='{{.Names}}' 2>/dev/null)
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+BUILDCTL_ARCHIVE := https://github.com/moby/buildkit/releases/download/$(BUILDKIT_VERSION)/buildkit-$(BUILDKIT_VERSION).linux-amd64.tar.gz
+endif
+ifeq ($(UNAME_S),Darwin)
+BUILDCTL_ARCHIVE := https://github.com/moby/buildkit/releases/download/$(BUILDKIT_VERSION)/buildkit-$(BUILDKIT_VERSION).darwin-amd64.tar.gz
+endif
+
+ifeq ($(UNAME_S),Linux)
+GITMETA := https://github.com/talos-systems/gitmeta/releases/download/v0.1.0-alpha.2/gitmeta-linux-amd64
+endif
+ifeq ($(UNAME_S),Darwin)
+GITMETA := https://github.com/talos-systems/gitmeta/releases/download/v0.1.0-alpha.2/gitmeta-darwin-amd64
+endif
+
+BINDIR ?= ./bin
+CONFORM_VERSION ?= 57c9dbd
+
+SHA ?= $(shell $(BINDIR)/gitmeta git sha)
+TAG ?= $(shell $(BINDIR)/gitmeta image tag)
+BRANCH ?= $(shell $(BINDIR)/gitmeta git branch)
+
+COMMON_ARGS = --progress=plain
+COMMON_ARGS += --frontend=dockerfile.v0
+COMMON_ARGS += --allow security.insecure
+COMMON_ARGS += --local context=.
+COMMON_ARGS += --local dockerfile=.
+COMMON_ARGS += --opt build-arg:TOOLS=$(TOOLS)
+COMMON_ARGS += --opt build-arg:SHA=$(SHA)
+COMMON_ARGS += --opt build-arg:TAG=$(TAG)
+COMMON_ARGS += --opt build-arg:GO_VERSION=$(GO_VERSION)
+
+DOCKER_ARGS ?=
+
+TESTPKGS ?= ./...
+
+all: protoc-gen-proxy
+
+.PHONY: ci
+ci: builddeps buildkitd
+
+.PHONY: builddeps
+builddeps: gitmeta buildctl
+
+gitmeta: $(BINDIR)/gitmeta
+
+$(BINDIR)/gitmeta:
+	@mkdir -p $(BINDIR)
+	@curl -L $(GITMETA) -o $(BINDIR)/gitmeta
+	@chmod +x $(BINDIR)/gitmeta
+
+buildctl: $(BINDIR)/buildctl
+
+$(BINDIR)/buildctl:
+	@mkdir -p $(BINDIR)
+	@curl -L $(BUILDCTL_ARCHIVE) | tar -zxf - -C $(BINDIR) --strip-components 1 bin/buildctl
+
+.PHONY: buildkitd
+buildkitd:
+ifeq (tcp://0.0.0.0:1234,$(findstring tcp://0.0.0.0:1234,$(BUILDKIT_HOST)))
+ifeq ($(BUILDKIT_CONTAINER_STOPPED),$(BUILDKIT_CONTAINER_NAME))
+	@echo "Removing exited talos-buildkit container"
+	@docker rm $(BUILDKIT_CONTAINER_NAME)
+endif
+ifneq ($(BUILDKIT_CONTAINER_RUNNING),$(BUILDKIT_CONTAINER_NAME))
+	@echo "Starting talos-buildkit container"
+	@docker run \
+		--name $(BUILDKIT_CONTAINER_NAME) \
+		-d \
+		--privileged \
+		-p 1234:1234 \
+		$(BUILDKIT_IMAGE) \
+		--addr $(BUILDKIT_HOST) \
+		--allow-insecure-entitlement security.insecure
+	@echo "Wait for buildkitd to become available"
+	@sleep 5
+endif
+endif
+
+protoc-gen-proxy: buildkitd
+	@mkdir -p build
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
+		build \
+		--output type=docker,dest=build/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
+		$(COMMON_ARGS)
+	@docker load < build/$@.tar
+
+.PHONY: push
+push: gitmeta login
+	@docker push autonomy/protoc-gen-proxy:$(TAG)
+ifeq ($(BRANCH),master)
+	@docker tag autonomy/installer:$(TAG) autonomy/protoc-gen-proxy:latest
+	@docker push autonomy/protoc-gen-proxy:latest
+endif
+
+.PHONY: unit-tests
+unit-tests: buildkitd
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
+		build \
+		--opt target=$@ \
+		--output type=local,dest=./ \
+		--opt build-arg:TESTPKGS=$(TESTPKGS) \
+		$(COMMON_ARGS)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # protoc-gen-proxy
-protoc plugin to extend grpc generation with proxy(multiplexing) functionality
+
+protoc plugin to extend grpc generation with proxy(multiplexing) functionality. This plugin is meant to be chained with the grpc plugin to add additional functionality to gRPC.
+
+## Usage
+
+```bash
+protoc -I./tests/proto --plugin=proxy --proxy_out=plugins=grpc+proxy:tests/proto tests/proto/api.proto
+```
+
+The following will extend the generated gRPC protobuf definition to include a `grpc.UnaryInterceptor` that will route incoming requests to any additional hosts specified in the `metadata["targets"]` field.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/talos-systems/protoc-gen-proxy
+
+go 1.12
+
+require github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
+
+	_ "github.com/golang/protobuf/protoc-gen-go/grpc"
+	_ "github.com/talos-systems/protoc-gen-proxy/pkg/proxy"
+)
+
+func main() {
+
+	// Begin by allocating a generator. The request and response structures are stored there
+	// so we can do error handling easily - the response structure contains the field to
+	// report failure.
+	g := generator.New()
+
+	data, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		g.Error(err, "reading input")
+	}
+
+	if err := proto.Unmarshal(data, g.Request); err != nil {
+		g.Error(err, "parsing input proto")
+	}
+
+	if len(g.Request.FileToGenerate) == 0 {
+		g.Fail("no files to generate")
+	}
+
+	g.CommandLineParameters(g.Request.GetParameter())
+
+	// Create a wrapped version of the Descriptors and EnumDescriptors that
+	// point to the file that defines them.
+	g.WrapTypes()
+
+	g.SetPackageNames()
+	g.BuildTypeNameMap()
+
+	g.GenerateAllFiles()
+
+	// Send back the results.
+	data, err = proto.Marshal(g.Response)
+	if err != nil {
+		g.Error(err, "failed to marshal output proto")
+	}
+
+	_, err = os.Stdout.Write(data)
+	if err != nil {
+		g.Error(err, "failed to write output proto")
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,369 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package proxy
+
+import (
+	"fmt"
+	"strings"
+
+	pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
+)
+
+// generatedCodeVersion indicates a version of the generated code.
+// It is incremented whenever an incompatibility between the generated code and
+// the grpc package is introduced; the generated code references
+// a constant, grpc.SupportPackageIsVersionN (where N is generatedCodeVersion).
+const generatedCodeVersion = 4
+
+// Paths for packages used by code generated in this file,
+// relative to the import_prefix of the generator.Generator.
+const (
+	contextPkgPath = "context"
+	grpcPkgPath    = "google.golang.org/grpc"
+	codePkgPath    = "google.golang.org/grpc/codes"
+	statusPkgPath  = "google.golang.org/grpc/status"
+)
+
+func init() {
+	generator.RegisterPlugin(new(proxy))
+}
+
+// grpc is an implementation of the Go protocol buffer compiler's
+// plugin architecture.  It generates bindings for gRPC support.
+type proxy struct {
+	gen *generator.Generator
+}
+
+// Name returns the name of this plugin, "grpc".
+func (g *proxy) Name() string {
+	return "proxy"
+}
+
+// The names for packages imported in the generated code.
+// They may vary from the final path component of the import path
+// if the name is used by other packages.
+var (
+	contextPkg string
+	grpcPkg    string
+)
+
+// Init initializes the plugin.
+func (g *proxy) Init(gen *generator.Generator) {
+	g.gen = gen
+}
+
+// Given a type name defined in a .proto, return its object.
+// Also record that we're using it, to guarantee the associated import.
+func (g *proxy) objectNamed(name string) generator.Object {
+	g.gen.RecordTypeUse(name)
+	return g.gen.ObjectNamed(name)
+}
+
+// Given a type name defined in a .proto, return its name as we will print it.
+func (g *proxy) typeName(str string) string {
+	return g.gen.TypeName(g.objectNamed(str))
+}
+
+// P forwards to g.gen.P.
+func (g *proxy) P(args ...interface{}) { g.gen.P(args...) }
+
+// GenerateImports generates the import declaration for this file.
+func (g *proxy) GenerateImports(file *generator.FileDescriptor) {
+}
+
+func (g *proxy) Generate(file *generator.FileDescriptor) {
+	g.gen.AddImport("strings")
+	g.gen.AddImport("sync")
+	g.gen.AddImport("google.golang.org/grpc/metadata")
+	g.gen.AddImport("google.golang.org/grpc/credentials")
+	g.gen.AddImport("github.com/hashicorp/go-multierror")
+	g.gen.AddImport("github.com/talos-systems/talos/pkg/grpc/tls")
+
+	for _, service := range file.FileDescriptorProto.Service {
+		serviceName := generator.CamelCase(service.GetName())
+		g.generateServiceFuncType(serviceName)
+		g.P("")
+		g.generateProxyClientStruct(serviceName)
+		g.P("")
+		g.generateProxyRunner(serviceName)
+		g.P("")
+		g.generateProxyStruct(serviceName)
+		g.P("")
+		g.generateProxyInterceptor(serviceName, file.GetPackage())
+		g.P("")
+		g.generateProxyRouter(serviceName, file.GetPackage(), service.Method)
+		for _, method := range service.Method {
+			// No support for streaming stuff yet
+			if method.GetServerStreaming() || method.GetClientStreaming() {
+				continue
+			}
+			g.P("")
+			g.generateServiceFunc(serviceName, method)
+		}
+	}
+}
+
+// generateServiceFuncType is a function with a specific signature. This function
+// gets passed through the 'runner' func to perform the actual client call.
+func (g *proxy) generateServiceFuncType(serviceName string) {
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("*proxy" + serviceName + "Client, ")
+	args.WriteString("interface{}, ")
+	args.WriteString("*sync.WaitGroup, ")
+	args.WriteString("chan proto.Message, ")
+	args.WriteString("chan error")
+	args.WriteString(")")
+	g.P("type runnerfn func" + args.String())
+}
+
+// generateProxyClientStruct holds the client connection and additional metadata
+// associated with each grpc ( client ) connection that the proxy creates. This
+// should only exist for the duration of the request.
+func (g *proxy) generateProxyClientStruct(serviceName string) {
+	g.P("type proxy" + serviceName + "Client struct {")
+	g.P("Conn " + serviceName + "Client")
+	g.P("Context context.Context")
+	g.P("Target string")
+	g.P("DialOpts []grpc.DialOption")
+	g.P("}")
+}
+
+// generateProxyStruct is the public struct exposed for use by importers. It
+// contains a tls provider to manage the TLS cert rotation/renewal. This also
+// generates the constructor for the struct.
+func (g *proxy) generateProxyStruct(serviceName string) {
+	tName := generator.CamelCase(serviceName + "_proxy")
+	g.P("type " + tName + " struct {")
+	g.P("Provider tls.CertificateProvider")
+	g.P("}")
+
+	g.P("")
+
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("provider tls.CertificateProvider")
+	args.WriteString(")")
+	g.P("func New" + tName + args.String() + " *" + tName + "{")
+	g.P("return &" + tName + "{Provider: provider}")
+	g.P("}")
+}
+
+// generateProxyInterceptor is a method of the proxy struct that satisfies the
+// grpc.UnaryInterceptor interface. This allows us to make use of the tls
+// information from the provider to include it with each subsequent request
+// from the proxy. This is also where we handle some of the routing decisions,
+// namely being able to filter on the supported service and handling the
+// 'proxyfrom' metadata field to prevent infinite loops.
+func (g *proxy) generateProxyInterceptor(serviceName string, pkgName string) {
+	tName := generator.CamelCase(serviceName + "_proxy")
+	fullServName := serviceName
+	if pkgName != "" {
+		fullServName = pkgName + "." + fullServName
+	}
+	g.P("func (p *" + tName + ") UnaryInterceptor() grpc.UnaryServerInterceptor {")
+	g.P("return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {")
+	// Artifically limit scope to OS api
+	g.P("pkg := strings.Split(info.FullMethod, \"/\")[1]")
+	g.P("if pkg != \"" + fullServName + "\" {")
+	g.P("return handler(ctx, req)")
+	g.P("}")
+	g.P("md, _ := metadata.FromIncomingContext(ctx)")
+	g.P("if _, ok := md[\"proxyfrom\"]; ok {")
+	g.P("return handler(ctx, req)")
+	g.P("}")
+	g.P("ca, err := p.Provider.GetCA()")
+	g.P("if err != nil {")
+	g.P("	return nil, err")
+	g.P("}")
+	g.P("certs, err := p.Provider.GetCertificate(nil)")
+	g.P("if err != nil {")
+	g.P("  return nil, err")
+	g.P("}")
+	g.P("tlsConfig, err := tls.New(")
+	g.P("  tls.WithClientAuthType(tls.Mutual),")
+	g.P("  tls.WithCACertPEM(ca),")
+	g.P("  tls.WithKeypair(*certs),")
+	g.P(")")
+	g.P("return p.Proxy(ctx, info.FullMethod, credentials.NewTLS(tlsConfig), req)")
+	g.P("}")
+	g.P("}")
+}
+
+// generateServiceFunc is a function generated for each service defined in the
+// proto file. The function signature satisfies the runnerfn type.
+func (g *proxy) generateServiceFunc(serviceName string, method *pb.MethodDescriptorProto) {
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("client *proxy" + serviceName + "Client, ")
+	args.WriteString("in interface{}, ")
+	args.WriteString("wg *sync.WaitGroup, ")
+	args.WriteString("respCh chan proto.Message, ")
+	args.WriteString("errCh chan error")
+	args.WriteString(")")
+
+	g.P("func proxy" + generator.CamelCase(method.GetName()) + args.String() + "{")
+	g.P("defer wg.Done()")
+	g.P("resp, err := client.Conn." + method.GetName() + "(client.Context, in.(*" + g.typeName(method.GetInputType()) + "))")
+	g.P("if err != nil {")
+	g.P("errCh<-err")
+	g.P("return")
+	g.P("}")
+	// TODO: See if we can better abstract this
+	g.P("resp.Response[0].Metadata = &NodeMetadata{Hostname: client.Target}")
+	g.P("respCh<-resp")
+	g.P("}")
+}
+
+// generateProxyRunner is the function that handles the client calls and response
+// aggregation.
+func (g *proxy) generateProxyRunner(serviceName string) {
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("clients []*proxy" + serviceName + "Client, ")
+	args.WriteString("in interface{}, ")
+	args.WriteString("runner runnerfn")
+	args.WriteString(")")
+
+	var returns strings.Builder
+	returns.WriteString("(")
+	returns.WriteString("[]proto.Message, ")
+	returns.WriteString("error")
+	returns.WriteString(")")
+
+	g.P("func proxy" + serviceName + "Runner" + args.String() + returns.String() + "{")
+	g.P("var (")
+	g.P("errors *go_multierror.Error")
+	g.P("wg sync.WaitGroup")
+	g.P(")")
+
+	g.P("respCh := make(chan proto.Message, len(clients))")
+	g.P("errCh := make(chan error, len(clients))")
+	g.P("wg.Add(len(clients))")
+
+	g.P("for _, client := range clients {")
+	g.P("go runner(client, in, &wg, respCh, errCh)")
+	g.P("}")
+
+	g.P("wg.Wait()")
+	g.P("close(respCh)")
+	g.P("close(errCh)")
+	g.P("")
+
+	g.P("var response []proto.Message")
+	g.P("for resp := range respCh {")
+	g.P("response = append(response, resp)")
+	g.P("}")
+
+	g.P("for err := range errCh {")
+	g.P("errors = go_multierror.Append(errors, err)")
+	g.P("}")
+
+	g.P("return response, errors.ErrorOrNil()")
+	g.P("}")
+}
+
+// generateProxyRouter creates the routing part of the proxy. That is it
+// enables us to map the incoming grpc method to the function/client call
+// so we can properly call the proper rpc endpoint.
+func (g *proxy) generateProxyRouter(serviceName string, pkgName string, methods []*pb.MethodDescriptorProto) {
+	// Leaving this in as left overs from grpc plugin, but not
+	// sure it really makes sense to keep it like this versus
+	// just calling the addimport call in Generate()
+	contextPkg = string(g.gen.AddImport(contextPkgPath))
+	grpcPkg = string(g.gen.AddImport(grpcPkgPath))
+
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("ctx " + contextPkg + ".Context, ")
+	args.WriteString("method string, ")
+	args.WriteString("creds credentials.TransportCredentials, ")
+	args.WriteString("in interface{}, ")
+	args.WriteString("opts ..." + grpcPkg + ".CallOption")
+	args.WriteString(")")
+
+	var returns strings.Builder
+	returns.WriteString("(")
+	returns.WriteString("proto.Message, ")
+	returns.WriteString("error")
+	returns.WriteString(")")
+
+	g.P("func (p *" + generator.CamelCase(serviceName+"_proxy") + ") Proxy " + args.String() + returns.String() + "{")
+	g.P("var (")
+	g.P("err error")
+	g.P("errors *go_multierror.Error")
+	g.P("msgs []proto.Message")
+	g.P("ok bool")
+	g.P("response proto.Message")
+	g.P("targets []string")
+	g.P(")")
+
+	// Parse targets from incoming metadata/context
+	g.P("md, _ := metadata.FromIncomingContext(ctx)")
+	g.P("// default to target node specified in config or on cli")
+	g.P("if targets, ok = md[\"targets\"]; !ok {")
+	g.P("targets = md[\":authority\"]")
+	g.P("}")
+
+	// Set up client connections
+	g.P("proxyMd := metadata.New(make(map[string]string))")
+	g.P("proxyMd.Set(\"proxyfrom\", md[\":authority\"]...)")
+	g.P("")
+	g.P("clients := []*proxy" + serviceName + "Client{}")
+	g.P("for _, target := range targets {")
+	g.P("c := &proxy" + serviceName + "Client{")
+	// TODO change the context to be more useful ( ex cancelable )
+	g.P("Context: metadata.NewOutgoingContext(context.Background(), proxyMd),")
+	g.P("Target:  target,")
+	g.P("}")
+	g.P("overrideCreds := creds")
+	// Explicitly set OSD port
+	// TODO: i think we potentially leak a client here,
+	// we should close the request // cancel the context if it errors
+	g.P("conn, err := grpc.Dial(fmt.Sprintf(\"%s:%d\", c.Target, 50000), grpc.WithTransportCredentials(overrideCreds))")
+	g.P("if err != nil {")
+	// TODO: probably worth wrapping err to add some context about the target
+	g.P("errors = go_multierror.Append(errors, err)")
+	g.P("continue")
+	g.P("}")
+	g.P("c.Conn = New" + serviceName + "Client(conn)")
+	g.P("clients = append(clients, c)")
+	g.P("}")
+
+	// Handle routes
+	g.P("switch method {")
+	for _, method := range methods {
+		// No support for streaming stuff yet
+		if method.GetServerStreaming() || method.GetClientStreaming() {
+			continue
+		}
+		fullServName := serviceName
+		if pkgName != "" {
+			fullServName = pkgName + "." + fullServName
+		}
+		sname := fmt.Sprintf("/%s/%s", fullServName, method.GetName())
+		g.P("case \"" + sname + "\":")
+		var fnArgs strings.Builder
+		fnArgs.WriteString("(")
+		fnArgs.WriteString("clients, ")
+		fnArgs.WriteString("in, ")
+		fnArgs.WriteString("proxy" + generator.CamelCase(method.GetName()))
+		fnArgs.WriteString(")")
+		g.P("resp := &" + g.typeName(method.GetOutputType()) + "{}")
+		g.P("msgs, err = proxy" + serviceName + "Runner" + fnArgs.String())
+		g.P("for _, msg := range msgs {")
+		g.P("resp.Response = append(resp.Response, msg.(*" + g.typeName(method.GetOutputType()) + ").Response[0])")
+		g.P("}")
+		g.P("response = resp")
+	}
+	g.P("}")
+	g.P("")
+	g.P("if err != nil {")
+	g.P("errors = go_multierror.Append(errors, err)")
+	g.P("}")
+	g.P("return response, errors.ErrorOrNil()")
+	g.P("}")
+}


### PR DESCRIPTION
Cleans up the PoC work to add in proxy functionality as part of the generated gRPC definition.
The proxy provides the ability to route an incoming request to N targets defined in the
request metadata.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>