### PR TITLE
feat: Generate APId code

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,37 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Go support for Protocol Buffers - Google's data interchange format
+//
+// Copyright 2010 The Go Authors.  All rights reserved.
+// https://github.com/golang/protobuf
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package main
 
 import (

--- a/pkg/proxy/generator.go
+++ b/pkg/proxy/generator.go
@@ -1,0 +1,281 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Go support for Protocol Buffers - Google's data interchange format
+//
+// Copyright 2010 The Go Authors.  All rights reserved.
+// https://github.com/golang/protobuf
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/golang/protobuf/protoc-gen-go/generator"
+)
+
+// generatedCodeVersion indicates a version of the generated code.
+// It is incremented whenever an incompatibility between the generated code and
+// the grpc package is introduced; the generated code references
+// a constant, grpc.SupportPackageIsVersionN (where N is generatedCodeVersion).
+const generatedCodeVersion = 4
+
+// Paths for packages used by code generated in this file,
+// relative to the import_prefix of the generator.Generator.
+const (
+	contextPkgPath = "context"
+	grpcPkgPath    = "google.golang.org/grpc"
+	codePkgPath    = "google.golang.org/grpc/codes"
+	statusPkgPath  = "google.golang.org/grpc/status"
+)
+
+func init() {
+	generator.RegisterPlugin(new(proxy))
+}
+
+// grpc is an implementation of the Go protocol buffer compiler's
+// plugin architecture.  It generates bindings for gRPC support.
+type proxy struct {
+	ProxySwitch         *bytes.Buffer
+	ProxyFns            *bytes.Buffer
+	InitClients         *bytes.Buffer
+	Clients             *bytes.Buffer
+	Registrator         *bytes.Buffer
+	RegistratorRegister *bytes.Buffer
+
+	GrpcClient *bytes.Buffer
+	GrpcServer *bytes.Buffer
+
+	WrapperFns *bytes.Buffer
+
+	gen *generator.Generator
+}
+
+// Name returns the name of this plugin, "proxy".
+func (g *proxy) Name() string {
+	return "proxy"
+}
+
+// The names for packages imported in the generated code.
+// They may vary from the final path component of the import path
+// if the name is used by other packages.
+var (
+	contextPkg string
+	grpcPkg    string
+)
+
+// Init initializes the plugin.
+func (g *proxy) Init(gen *generator.Generator) {
+	g.gen = gen
+	g.ProxySwitch = new(bytes.Buffer)
+	g.ProxyFns = new(bytes.Buffer)
+	g.InitClients = new(bytes.Buffer)
+	g.Clients = new(bytes.Buffer)
+	g.WrapperFns = new(bytes.Buffer)
+	g.Registrator = new(bytes.Buffer)
+	g.RegistratorRegister = new(bytes.Buffer)
+	g.GrpcClient = new(bytes.Buffer)
+	g.GrpcServer = new(bytes.Buffer)
+}
+
+// Given a type name defined in a .proto, return its object.
+// Also record that we're using it, to guarantee the associated import.
+func (g *proxy) objectNamed(name string) generator.Object {
+	g.gen.RecordTypeUse(name)
+	return g.gen.ObjectNamed(name)
+}
+
+// Given a type name defined in a .proto, return its name as we will print it.
+func (g *proxy) typeName(str string) string {
+	return g.gen.TypeName(g.objectNamed(str))
+}
+
+// P writes to internal (*proxy) buffers that later get consumed by
+// g.gen.P(buffer.String())
+func (g *proxy) P(w *bytes.Buffer, str ...interface{}) {
+	for _, v := range str {
+		g.printAtom(w, v)
+	}
+	w.WriteByte('\n')
+}
+
+// printAtom prints the (atomic, non-annotation) argument to the generated output.
+func (g *proxy) printAtom(w *bytes.Buffer, v interface{}) {
+	switch v := v.(type) {
+	case string:
+		w.WriteString(v)
+	case *string:
+		w.WriteString(*v)
+	case bool:
+		fmt.Fprint(w, v)
+	case *bool:
+		fmt.Fprint(w, *v)
+	case int:
+		fmt.Fprint(w, v)
+	case *int32:
+		fmt.Fprint(w, *v)
+	case *int64:
+		fmt.Fprint(w, *v)
+	case float64:
+		fmt.Fprint(w, v)
+	case *float64:
+		fmt.Fprint(w, *v)
+	case generator.GoPackageName:
+		w.WriteString(string(v))
+	case generator.GoImportPath:
+		w.WriteString(strconv.Quote(string(v)))
+	default:
+		g.gen.Fail(fmt.Sprintf("unknown type in printer: %T", v))
+	}
+}
+
+// GenerateImports generates the import declaration for this file.
+func (g *proxy) GenerateImports(file *generator.FileDescriptor) {
+}
+
+// Generate is the main entrypoint to the plugin. This is where all
+// the magic happens.
+func (g *proxy) Generate(file *generator.FileDescriptor) {
+	// Try to filter out non-builtins
+	// ex, we don't want to do this for  google/protobuf/empty.proto
+	if strings.Contains(*file.Package, "google") {
+		return
+	}
+
+	// If we're dealing with the actual file to generate,
+	// we'll print out everything we've generated so far ( all stored
+	// bytes.Buffers ) and we'll generate the high level wrappers
+	// like `Proxy()`, `UnaryInterceptor()`, `Runner()`
+	for _, f := range g.gen.Request.FileToGenerate {
+		if file.GetName() == f {
+			g.generate(file)
+			return
+		}
+	}
+
+	// Otherwise, we'll generate all the fun per package/proto
+	// imports and switch statements so we can satisfy the
+	// - switch statement cases
+	// - various function definitions
+	// - client creation functions
+	for _, service := range file.FileDescriptorProto.Service {
+		serviceName := generator.CamelCase(service.GetName())
+
+		// g.ProxySwitch
+		g.generateSwitchStatement(serviceName, file.GetPackage(), service.Method)
+
+		// g.ProxyFns
+		g.generateServiceFuncType(serviceName)
+		g.generateServiceRunner(serviceName)
+		g.generateProxyClientStruct(serviceName, file.GetPackage())
+
+		for _, method := range service.Method {
+			// No support for streaming stuff yet
+			if method.GetServerStreaming() || method.GetClientStreaming() {
+				continue
+			}
+
+			// g.ProxyFns
+			g.generateServiceFunc(serviceName, method)
+		}
+
+		// g.Clients
+		g.generateClientFns(serviceName, file.GetPackage())
+
+		// g.Registrator
+		g.generateRegistrator(service, file.GetPackage())
+
+		// g.RegistratorRegister
+		g.generateRegistratorRegister(service, file.GetPackage())
+
+		for _, method := range service.Method {
+			// Need to generate a full set of methods to satisfy
+			// the server interface
+
+			// g.GrpcServer
+			g.generateServerMethods(serviceName, file.GetPackage(), method)
+		}
+
+		// g.GrpcClient
+		g.generateLocalClient(serviceName, file.GetPackage())
+
+		for _, method := range service.Method {
+			// Need to generate a full set of methods to satisfy
+			// the client interface
+
+			// g.GrpcClient
+			g.generateClientMethods(serviceName, file.GetPackage(), method)
+		}
+	}
+}
+
+func (g *proxy) generate(file *generator.FileDescriptor) {
+	g.gen.AddImport("io")
+	g.gen.AddImport("sync")
+	g.gen.AddImport("google.golang.org/grpc/metadata")
+	g.gen.AddImport("google.golang.org/grpc/credentials")
+	g.gen.AddImport("github.com/hashicorp/go-multierror")
+	// Support `provider`
+	g.gen.AddImport("github.com/talos-systems/talos/pkg/grpc/tls")
+	// Support for socket paths
+	g.gen.AddImport("github.com/talos-systems/talos/pkg/constants")
+
+	g.generateProxyStruct(file.GetPackage())
+
+	g.generateProxyInterceptor(file.GetPackage())
+
+	g.generateProxyRouter(file.GetPackage())
+
+	g.generateStreamCopyHelper()
+
+	g.gen.P(g.ProxyFns.String())
+	g.gen.P("")
+
+	g.gen.P(g.Clients.String())
+	g.gen.P("")
+
+	g.gen.P("type Registrator struct {")
+	g.gen.P(g.Registrator.String())
+	g.gen.P("}")
+	g.gen.P("")
+
+	g.gen.P("func (r *Registrator) Register(s *grpc.Server) {")
+	g.gen.P(g.RegistratorRegister.String())
+	g.gen.P("}")
+	g.gen.P("")
+
+	g.gen.P(g.GrpcServer.String())
+	g.gen.P("")
+
+	g.gen.P(g.GrpcClient.String())
+}

--- a/pkg/proxy/grpc_clients.go
+++ b/pkg/proxy/grpc_clients.go
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package proxy
+
+import (
+	"strings"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
+)
+
+// generateLocalClient generates a local ( as in served by the host itself )
+// client to connect with the other node local grpc endpoints.
+func (g *proxy) generateLocalClient(serviceName, pkgName string) {
+	// type
+	g.P(g.GrpcClient, "type Local"+serviceName+"Client struct {")
+	g.P(g.GrpcClient, pkgName+"."+serviceName+"Client")
+	g.P(g.GrpcClient, "}")
+	g.P(g.GrpcClient, "")
+
+	// constructor
+	g.P(g.GrpcClient, "func NewLocal"+serviceName+"Client() ("+pkgName+"."+serviceName+"Client, error) {")
+	g.P(g.GrpcClient, "conn, err := grpc.Dial(\"unix:\"+constants."+serviceName+"SocketPath,")
+	g.P(g.GrpcClient, "grpc.WithInsecure(),")
+	g.P(g.GrpcClient, ")")
+	g.P(g.GrpcClient, "if err != nil {")
+	g.P(g.GrpcClient, "return nil, err")
+	g.P(g.GrpcClient, "}")
+	g.P(g.GrpcClient, "return &Local"+serviceName+"Client{")
+	g.P(g.GrpcClient, serviceName+"Client: "+pkgName+".New"+serviceName+"Client(conn),")
+	g.P(g.GrpcClient, "}, nil")
+	g.P(g.GrpcClient, "}")
+	g.P(g.GrpcClient, "")
+}
+
+// generateClientMethods generates the methods to satisfy the XXClient interface.
+// These methods are part of the Local<serviceName>Client struct.
+func (g *proxy) generateClientMethods(serviceName, pkgName string, method *descriptor.MethodDescriptorProto) {
+	// method arguments
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("ctx context.Context")
+	args.WriteString(", in *" + g.typeName(method.GetInputType()))
+	args.WriteString(", opts ...grpc.CallOption")
+	args.WriteString(")")
+
+	// method returns
+	var returns strings.Builder
+	returns.WriteString("(")
+	if method.GetServerStreaming() || method.GetClientStreaming() {
+		returns.WriteString(pkgName + "." + serviceName + "_" + generator.CamelCase(method.GetName()) + "Client")
+	} else {
+		returns.WriteString("*" + g.typeName(method.GetOutputType()))
+	}
+	returns.WriteString(", error")
+	returns.WriteString(")")
+
+	// method definition
+	g.P(g.GrpcClient, "func (c *Local"+serviceName+"Client) "+method.GetName()+args.String()+returns.String()+"{")
+	g.P(g.GrpcClient, "return c."+serviceName+"Client."+method.GetName()+"(ctx, in, opts...)")
+	g.P(g.GrpcClient, "}")
+
+}

--- a/pkg/proxy/grpc_servers.go
+++ b/pkg/proxy/grpc_servers.go
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package proxy
+
+import (
+	"strings"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
+)
+
+// generateRegistrator generates the embedded types for the registrator.
+func (g *proxy) generateRegistrator(service *descriptor.ServiceDescriptorProto, pkgName string) {
+	serviceName := generator.CamelCase(service.GetName())
+	g.P(g.Registrator, pkgName+"."+serviceName+"Client")
+}
+
+// generateRegistratorRegister generates the grpc server registration calls.
+func (g *proxy) generateRegistratorRegister(service *descriptor.ServiceDescriptorProto, pkgName string) {
+	serviceName := generator.CamelCase(service.GetName())
+	g.P(g.RegistratorRegister, pkgName+"."+"Register"+serviceName+"Server(s,r)")
+}
+
+// generateGRPCServers generates the methods to satisfy the XXServer interface.
+// This differs ever so slightly from the XXClient interface.
+func (g *proxy) generateServerMethods(serviceName, pkgName string, method *descriptor.MethodDescriptorProto) {
+	if method.GetServerStreaming() || method.GetClientStreaming() {
+		g.generateServerStreamMethods(serviceName, pkgName, method)
+	} else {
+		g.generateServerUnaryMethods(serviceName, pkgName, method)
+	}
+}
+
+func (g *proxy) generateServerUnaryMethods(serviceName, pkgName string, method *descriptor.MethodDescriptorProto) {
+	var serverArgs strings.Builder
+	serverArgs.WriteString("(")
+	serverArgs.WriteString("ctx context.Context, ")
+	serverArgs.WriteString("in *" + g.typeName(method.GetInputType()))
+	serverArgs.WriteString(")")
+
+	var serverReturns strings.Builder
+	serverReturns.WriteString("(")
+	serverReturns.WriteString("*" + g.typeName(method.GetOutputType()) + ", ")
+	serverReturns.WriteString("error")
+	serverReturns.WriteString(")")
+
+	g.P(g.GrpcServer, "func (r *Registrator) "+method.GetName()+serverArgs.String()+serverReturns.String()+"{")
+	g.P(g.GrpcServer, "return r."+serviceName+"Client."+method.GetName()+"(ctx, in)")
+	g.P(g.GrpcServer, "}")
+}
+func (g *proxy) generateServerStreamMethods(serviceName, pkgName string, method *descriptor.MethodDescriptorProto) {
+	var serverArgs strings.Builder
+	serverArgs.WriteString("(")
+	serverArgs.WriteString("in *" + g.typeName(method.GetInputType()))
+	serverArgs.WriteString(", srv " + pkgName + "." + serviceName + "_" + generator.CamelCase(method.GetName()) + "Server, ")
+	serverArgs.WriteString(")")
+
+	var serverReturns strings.Builder
+	serverReturns.WriteString("(")
+	serverReturns.WriteString("error")
+	serverReturns.WriteString(")")
+
+	g.P(g.GrpcServer, "func (r *Registrator) "+method.GetName()+
+		serverArgs.String()+serverReturns.String()+"{")
+
+	g.P(g.GrpcServer, "client, err := r."+serviceName+"Client."+method.GetName()+"(srv.Context(), in)")
+	g.P(g.GrpcServer, "if err != nil {")
+	g.P(g.GrpcServer, "return err")
+	g.P(g.GrpcServer, "}")
+	g.P(g.GrpcServer, "var msg "+g.typeName(method.GetOutputType()))
+	g.P(g.GrpcServer, "return copyClientServer(&msg, client, srv)")
+
+	g.P(g.GrpcServer, "}")
+}

--- a/pkg/proxy/interceptor.go
+++ b/pkg/proxy/interceptor.go
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package proxy
+
+import "github.com/golang/protobuf/protoc-gen-go/generator"
+
+// generateProxyInterceptor is a method of the proxy struct that satisfies the
+// grpc.UnaryInterceptor interface. This allows us to make use of the tls
+// information from the provider to include it with each subsequent request
+// from the proxy. This is also where we handle some of the routing decisions,
+// namely being able to filter on the supported service and handling the
+// 'proxyfrom' metadata field to prevent infinite loops.
+func (g *proxy) generateProxyInterceptor(serviceName string) {
+	tName := generator.CamelCase(serviceName + "_proxy")
+	g.gen.P("func (p *" + tName + ") UnaryInterceptor() grpc.UnaryServerInterceptor {")
+	g.gen.P("return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {")
+	g.gen.P("md, _ := metadata.FromIncomingContext(ctx)")
+	g.gen.P("if _, ok := md[\"proxyfrom\"]; ok {")
+	g.gen.P("return handler(ctx, req)")
+	g.gen.P("}")
+	g.gen.P("ca, err := p.Provider.GetCA()")
+	g.gen.P("if err != nil {")
+	g.gen.P("	return nil, err")
+	g.gen.P("}")
+	g.gen.P("certs, err := p.Provider.GetCertificate(nil)")
+	g.gen.P("if err != nil {")
+	g.gen.P("  return nil, err")
+	g.gen.P("}")
+	g.gen.P("tlsConfig, err := tls.New(")
+	g.gen.P("  tls.WithClientAuthType(tls.Mutual),")
+	g.gen.P("  tls.WithCACertPEM(ca),")
+	g.gen.P("  tls.WithKeypair(*certs),")
+	g.gen.P(")")
+	g.gen.P("return p.Proxy(ctx, info.FullMethod, credentials.NewTLS(tlsConfig), req)")
+	g.gen.P("}")
+	g.gen.P("}")
+	g.gen.P("")
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -12,124 +12,17 @@ import (
 	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
-// generatedCodeVersion indicates a version of the generated code.
-// It is incremented whenever an incompatibility between the generated code and
-// the grpc package is introduced; the generated code references
-// a constant, grpc.SupportPackageIsVersionN (where N is generatedCodeVersion).
-const generatedCodeVersion = 4
-
-// Paths for packages used by code generated in this file,
-// relative to the import_prefix of the generator.Generator.
-const (
-	contextPkgPath = "context"
-	grpcPkgPath    = "google.golang.org/grpc"
-	codePkgPath    = "google.golang.org/grpc/codes"
-	statusPkgPath  = "google.golang.org/grpc/status"
-)
-
-func init() {
-	generator.RegisterPlugin(new(proxy))
-}
-
-// grpc is an implementation of the Go protocol buffer compiler's
-// plugin architecture.  It generates bindings for gRPC support.
-type proxy struct {
-	gen *generator.Generator
-}
-
-// Name returns the name of this plugin, "grpc".
-func (g *proxy) Name() string {
-	return "proxy"
-}
-
-// The names for packages imported in the generated code.
-// They may vary from the final path component of the import path
-// if the name is used by other packages.
-var (
-	contextPkg string
-	grpcPkg    string
-)
-
-// Init initializes the plugin.
-func (g *proxy) Init(gen *generator.Generator) {
-	g.gen = gen
-}
-
-// Given a type name defined in a .proto, return its object.
-// Also record that we're using it, to guarantee the associated import.
-func (g *proxy) objectNamed(name string) generator.Object {
-	g.gen.RecordTypeUse(name)
-	return g.gen.ObjectNamed(name)
-}
-
-// Given a type name defined in a .proto, return its name as we will print it.
-func (g *proxy) typeName(str string) string {
-	return g.gen.TypeName(g.objectNamed(str))
-}
-
-// P forwards to g.gen.P.
-func (g *proxy) P(args ...interface{}) { g.gen.P(args...) }
-
-// GenerateImports generates the import declaration for this file.
-func (g *proxy) GenerateImports(file *generator.FileDescriptor) {
-}
-
-func (g *proxy) Generate(file *generator.FileDescriptor) {
-	g.gen.AddImport("strings")
-	g.gen.AddImport("sync")
-	g.gen.AddImport("google.golang.org/grpc/metadata")
-	g.gen.AddImport("google.golang.org/grpc/credentials")
-	g.gen.AddImport("github.com/hashicorp/go-multierror")
-	g.gen.AddImport("github.com/talos-systems/talos/pkg/grpc/tls")
-
-	for _, service := range file.FileDescriptorProto.Service {
-		serviceName := generator.CamelCase(service.GetName())
-		g.generateServiceFuncType(serviceName)
-		g.P("")
-		g.generateProxyClientStruct(serviceName)
-		g.P("")
-		g.generateProxyRunner(serviceName)
-		g.P("")
-		g.generateProxyStruct(serviceName)
-		g.P("")
-		g.generateProxyInterceptor(serviceName, file.GetPackage())
-		g.P("")
-		g.generateProxyRouter(serviceName, file.GetPackage(), service.Method)
-		for _, method := range service.Method {
-			// No support for streaming stuff yet
-			if method.GetServerStreaming() || method.GetClientStreaming() {
-				continue
-			}
-			g.P("")
-			g.generateServiceFunc(serviceName, method)
-		}
-	}
-}
-
-// generateServiceFuncType is a function with a specific signature. This function
-// gets passed through the 'runner' func to perform the actual client call.
-func (g *proxy) generateServiceFuncType(serviceName string) {
-	var args strings.Builder
-	args.WriteString("(")
-	args.WriteString("*proxy" + serviceName + "Client, ")
-	args.WriteString("interface{}, ")
-	args.WriteString("*sync.WaitGroup, ")
-	args.WriteString("chan proto.Message, ")
-	args.WriteString("chan error")
-	args.WriteString(")")
-	g.P("type runnerfn func" + args.String())
-}
-
 // generateProxyClientStruct holds the client connection and additional metadata
 // associated with each grpc ( client ) connection that the proxy creates. This
 // should only exist for the duration of the request.
-func (g *proxy) generateProxyClientStruct(serviceName string) {
-	g.P("type proxy" + serviceName + "Client struct {")
-	g.P("Conn " + serviceName + "Client")
-	g.P("Context context.Context")
-	g.P("Target string")
-	g.P("DialOpts []grpc.DialOption")
-	g.P("}")
+func (g *proxy) generateProxyClientStruct(serviceName, pkgName string) {
+	g.P(g.ProxyFns, "type proxy"+serviceName+"Client struct {")
+	g.P(g.ProxyFns, "Conn "+pkgName+"."+serviceName+"Client")
+	g.P(g.ProxyFns, "Context context.Context")
+	g.P(g.ProxyFns, "Target string")
+	g.P(g.ProxyFns, "DialOpts []grpc.DialOption")
+	g.P(g.ProxyFns, "}")
+	g.P(g.ProxyFns, "")
 }
 
 // generateProxyStruct is the public struct exposed for use by importers. It
@@ -137,139 +30,27 @@ func (g *proxy) generateProxyClientStruct(serviceName string) {
 // generates the constructor for the struct.
 func (g *proxy) generateProxyStruct(serviceName string) {
 	tName := generator.CamelCase(serviceName + "_proxy")
-	g.P("type " + tName + " struct {")
-	g.P("Provider tls.CertificateProvider")
-	g.P("}")
-
-	g.P("")
+	g.gen.P("type " + tName + " struct {")
+	g.gen.P("Provider tls.CertificateProvider")
+	g.gen.P("}")
+	g.gen.P("")
 
 	var args strings.Builder
 	args.WriteString("(")
 	args.WriteString("provider tls.CertificateProvider")
 	args.WriteString(")")
-	g.P("func New" + tName + args.String() + " *" + tName + "{")
-	g.P("return &" + tName + "{Provider: provider}")
-	g.P("}")
-}
-
-// generateProxyInterceptor is a method of the proxy struct that satisfies the
-// grpc.UnaryInterceptor interface. This allows us to make use of the tls
-// information from the provider to include it with each subsequent request
-// from the proxy. This is also where we handle some of the routing decisions,
-// namely being able to filter on the supported service and handling the
-// 'proxyfrom' metadata field to prevent infinite loops.
-func (g *proxy) generateProxyInterceptor(serviceName string, pkgName string) {
-	tName := generator.CamelCase(serviceName + "_proxy")
-	fullServName := serviceName
-	if pkgName != "" {
-		fullServName = pkgName + "." + fullServName
-	}
-	g.P("func (p *" + tName + ") UnaryInterceptor() grpc.UnaryServerInterceptor {")
-	g.P("return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {")
-	// Artifically limit scope to OS api
-	g.P("pkg := strings.Split(info.FullMethod, \"/\")[1]")
-	g.P("if pkg != \"" + fullServName + "\" {")
-	g.P("return handler(ctx, req)")
-	g.P("}")
-	g.P("md, _ := metadata.FromIncomingContext(ctx)")
-	g.P("if _, ok := md[\"proxyfrom\"]; ok {")
-	g.P("return handler(ctx, req)")
-	g.P("}")
-	g.P("ca, err := p.Provider.GetCA()")
-	g.P("if err != nil {")
-	g.P("	return nil, err")
-	g.P("}")
-	g.P("certs, err := p.Provider.GetCertificate(nil)")
-	g.P("if err != nil {")
-	g.P("  return nil, err")
-	g.P("}")
-	g.P("tlsConfig, err := tls.New(")
-	g.P("  tls.WithClientAuthType(tls.Mutual),")
-	g.P("  tls.WithCACertPEM(ca),")
-	g.P("  tls.WithKeypair(*certs),")
-	g.P(")")
-	g.P("return p.Proxy(ctx, info.FullMethod, credentials.NewTLS(tlsConfig), req)")
-	g.P("}")
-	g.P("}")
-}
-
-// generateServiceFunc is a function generated for each service defined in the
-// proto file. The function signature satisfies the runnerfn type.
-func (g *proxy) generateServiceFunc(serviceName string, method *pb.MethodDescriptorProto) {
-	var args strings.Builder
-	args.WriteString("(")
-	args.WriteString("client *proxy" + serviceName + "Client, ")
-	args.WriteString("in interface{}, ")
-	args.WriteString("wg *sync.WaitGroup, ")
-	args.WriteString("respCh chan proto.Message, ")
-	args.WriteString("errCh chan error")
-	args.WriteString(")")
-
-	g.P("func proxy" + generator.CamelCase(method.GetName()) + args.String() + "{")
-	g.P("defer wg.Done()")
-	g.P("resp, err := client.Conn." + method.GetName() + "(client.Context, in.(*" + g.typeName(method.GetInputType()) + "))")
-	g.P("if err != nil {")
-	g.P("errCh<-err")
-	g.P("return")
-	g.P("}")
-	// TODO: See if we can better abstract this
-	g.P("resp.Response[0].Metadata = &NodeMetadata{Hostname: client.Target}")
-	g.P("respCh<-resp")
-	g.P("}")
-}
-
-// generateProxyRunner is the function that handles the client calls and response
-// aggregation.
-func (g *proxy) generateProxyRunner(serviceName string) {
-	var args strings.Builder
-	args.WriteString("(")
-	args.WriteString("clients []*proxy" + serviceName + "Client, ")
-	args.WriteString("in interface{}, ")
-	args.WriteString("runner runnerfn")
-	args.WriteString(")")
-
-	var returns strings.Builder
-	returns.WriteString("(")
-	returns.WriteString("[]proto.Message, ")
-	returns.WriteString("error")
-	returns.WriteString(")")
-
-	g.P("func proxy" + serviceName + "Runner" + args.String() + returns.String() + "{")
-	g.P("var (")
-	g.P("errors *go_multierror.Error")
-	g.P("wg sync.WaitGroup")
-	g.P(")")
-
-	g.P("respCh := make(chan proto.Message, len(clients))")
-	g.P("errCh := make(chan error, len(clients))")
-	g.P("wg.Add(len(clients))")
-
-	g.P("for _, client := range clients {")
-	g.P("go runner(client, in, &wg, respCh, errCh)")
-	g.P("}")
-
-	g.P("wg.Wait()")
-	g.P("close(respCh)")
-	g.P("close(errCh)")
-	g.P("")
-
-	g.P("var response []proto.Message")
-	g.P("for resp := range respCh {")
-	g.P("response = append(response, resp)")
-	g.P("}")
-
-	g.P("for err := range errCh {")
-	g.P("errors = go_multierror.Append(errors, err)")
-	g.P("}")
-
-	g.P("return response, errors.ErrorOrNil()")
-	g.P("}")
+	g.gen.P("func New" + tName + args.String() + " *" + tName + "{")
+	g.gen.P("return &" + tName + "{")
+	g.gen.P("Provider: provider,")
+	g.gen.P("}")
+	g.gen.P("}")
+	g.gen.P("")
 }
 
 // generateProxyRouter creates the routing part of the proxy. That is it
 // enables us to map the incoming grpc method to the function/client call
 // so we can properly call the proper rpc endpoint.
-func (g *proxy) generateProxyRouter(serviceName string, pkgName string, methods []*pb.MethodDescriptorProto) {
+func (g *proxy) generateProxyRouter(serviceName string) {
 	// Leaving this in as left overs from grpc plugin, but not
 	// sure it really makes sense to keep it like this versus
 	// just calling the addimport call in Generate()
@@ -291,53 +72,48 @@ func (g *proxy) generateProxyRouter(serviceName string, pkgName string, methods 
 	returns.WriteString("error")
 	returns.WriteString(")")
 
-	g.P("func (p *" + generator.CamelCase(serviceName+"_proxy") + ") Proxy " + args.String() + returns.String() + "{")
-	g.P("var (")
-	g.P("err error")
-	g.P("errors *go_multierror.Error")
-	g.P("msgs []proto.Message")
-	g.P("ok bool")
-	g.P("response proto.Message")
-	g.P("targets []string")
-	g.P(")")
+	g.gen.P("func (p *" + generator.CamelCase(serviceName+"_proxy") + ") Proxy " + args.String() + returns.String() + "{")
+	g.gen.P("var (")
+	g.gen.P("err error")
+	g.gen.P("errors *go_multierror.Error")
+	g.gen.P("msgs []proto.Message")
+	g.gen.P("ok bool")
+	g.gen.P("response proto.Message")
+	g.gen.P("targets []string")
+	g.gen.P(")")
 
 	// Parse targets from incoming metadata/context
-	g.P("md, _ := metadata.FromIncomingContext(ctx)")
-	g.P("// default to target node specified in config or on cli")
-	g.P("if targets, ok = md[\"targets\"]; !ok {")
-	g.P("targets = md[\":authority\"]")
-	g.P("}")
+	g.gen.P("md, _ := metadata.FromIncomingContext(ctx)")
+	g.gen.P("// default to target node specified in config or on cli")
+	g.gen.P("if targets, ok = md[\"targets\"]; !ok {")
+	g.gen.P("targets = md[\":authority\"]")
+	g.gen.P("}")
 
 	// Set up client connections
-	g.P("proxyMd := metadata.New(make(map[string]string))")
-	g.P("proxyMd.Set(\"proxyfrom\", md[\":authority\"]...)")
-	g.P("")
-	g.P("clients := []*proxy" + serviceName + "Client{}")
-	g.P("for _, target := range targets {")
-	g.P("c := &proxy" + serviceName + "Client{")
-	// TODO change the context to be more useful ( ex cancelable )
-	g.P("Context: metadata.NewOutgoingContext(context.Background(), proxyMd),")
-	g.P("Target:  target,")
-	g.P("}")
-	g.P("overrideCreds := creds")
-	// Explicitly set OSD port
-	// TODO: i think we potentially leak a client here,
-	// we should close the request // cancel the context if it errors
-	g.P("conn, err := grpc.Dial(fmt.Sprintf(\"%s:%d\", c.Target, 50000), grpc.WithTransportCredentials(overrideCreds))")
-	g.P("if err != nil {")
-	// TODO: probably worth wrapping err to add some context about the target
-	g.P("errors = go_multierror.Append(errors, err)")
-	g.P("continue")
-	g.P("}")
-	g.P("c.Conn = New" + serviceName + "Client(conn)")
-	g.P("clients = append(clients, c)")
-	g.P("}")
+	g.gen.P("proxyMd := metadata.New(make(map[string]string))")
+	g.gen.P("proxyMd.Set(\"proxyfrom\", md[\":authority\"]...)")
+	g.gen.P("")
 
 	// Handle routes
-	g.P("switch method {")
+	g.gen.P("switch method {")
+	g.gen.P(g.ProxySwitch.String())
+	g.gen.P("}")
+	g.gen.P("")
+	g.gen.P("if err != nil {")
+	g.gen.P("errors = go_multierror.Append(errors, err)")
+	g.gen.P("}")
+	g.gen.P("return response, errors.ErrorOrNil()")
+	g.gen.P("}")
+}
+
+func (g *proxy) generateSwitchStatement(serviceName, pkgName string, methods []*pb.MethodDescriptorProto) {
 	for _, method := range methods {
 		// No support for streaming stuff yet
 		if method.GetServerStreaming() || method.GetClientStreaming() {
+			continue
+		}
+		// skip support for deprecated methods
+		if method.GetOptions().GetDeprecated() {
 			continue
 		}
 		fullServName := serviceName
@@ -345,25 +121,48 @@ func (g *proxy) generateProxyRouter(serviceName string, pkgName string, methods 
 			fullServName = pkgName + "." + fullServName
 		}
 		sname := fmt.Sprintf("/%s/%s", fullServName, method.GetName())
-		g.P("case \"" + sname + "\":")
+		g.P(g.ProxySwitch, "case \""+sname+"\":")
+		g.P(g.ProxySwitch, "// Initialize target clients")
+		g.P(g.ProxySwitch, "clients, err := create"+serviceName+"Client(targets, creds, proxyMd)")
+		g.P(g.ProxySwitch, "if err != nil {")
+		g.P(g.ProxySwitch, "break")
+		g.P(g.ProxySwitch, "}")
+
 		var fnArgs strings.Builder
 		fnArgs.WriteString("(")
 		fnArgs.WriteString("clients, ")
 		fnArgs.WriteString("in, ")
 		fnArgs.WriteString("proxy" + generator.CamelCase(method.GetName()))
 		fnArgs.WriteString(")")
-		g.P("resp := &" + g.typeName(method.GetOutputType()) + "{}")
-		g.P("msgs, err = proxy" + serviceName + "Runner" + fnArgs.String())
-		g.P("for _, msg := range msgs {")
-		g.P("resp.Response = append(resp.Response, msg.(*" + g.typeName(method.GetOutputType()) + ").Response[0])")
-		g.P("}")
-		g.P("response = resp")
+
+		g.P(g.ProxySwitch, "resp := &"+g.typeName(method.GetOutputType())+"{}")
+		g.P(g.ProxySwitch, "msgs, err = proxy"+serviceName+"Runner"+fnArgs.String())
+		g.P(g.ProxySwitch, "for _, msg := range msgs {")
+		g.P(g.ProxySwitch, "resp.Response = append(resp.Response, msg.(*"+g.typeName(method.GetOutputType())+").Response[0])")
+		g.P(g.ProxySwitch, "}")
+		g.P(g.ProxySwitch, "response = resp")
 	}
-	g.P("}")
-	g.P("")
-	g.P("if err != nil {")
-	g.P("errors = go_multierror.Append(errors, err)")
-	g.P("}")
-	g.P("return response, errors.ErrorOrNil()")
-	g.P("}")
+}
+
+func (g *proxy) generateStreamCopyHelper() {
+	g.gen.P("func copyClientServer(msg interface{}, client grpc.ClientStream, srv grpc.ServerStream) error {")
+	g.gen.P("	for {")
+	g.gen.P("		err := client.RecvMsg(msg)")
+	g.gen.P("		if err == io.EOF {")
+	g.gen.P("			break")
+	g.gen.P("		}")
+	g.gen.P("")
+	g.gen.P("		if err != nil {")
+	g.gen.P("			return err")
+	g.gen.P("		}")
+	g.gen.P("")
+	g.gen.P("		err = srv.SendMsg(msg)")
+	g.gen.P("		if err != nil {")
+	g.gen.P("			return err")
+	g.gen.P("		}")
+	g.gen.P("	}")
+	g.gen.P("")
+	g.gen.P("	return nil")
+	g.gen.P("}")
+	g.gen.P("")
 }

--- a/pkg/proxy/services.go
+++ b/pkg/proxy/services.go
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package proxy
+
+import (
+	"strings"
+
+	pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
+)
+
+// generateServiceFuncType is a function with a specific signature. This function
+// gets passed through the 'runner' func to perform the actual client call.
+func (g *proxy) generateServiceFuncType(serviceName string) {
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("*proxy" + serviceName + "Client, ")
+	args.WriteString("interface{}, ")
+	args.WriteString("*sync.WaitGroup, ")
+	args.WriteString("chan proto.Message, ")
+	args.WriteString("chan error")
+	args.WriteString(")")
+	g.P(g.ProxyFns, "type runner"+generator.CamelCase(serviceName+"_fn")+" func"+args.String())
+	g.P(g.ProxyFns, "")
+}
+
+// generateServiceFunc is a function generated for each service defined in the
+// proto file. The function signature satisfies the runnerfn type.
+func (g *proxy) generateServiceFunc(serviceName string, method *pb.MethodDescriptorProto) {
+	// skip support for deprecated methods
+	if method.GetOptions().GetDeprecated() {
+		return
+	}
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("client *proxy" + serviceName + "Client, ")
+	args.WriteString("in interface{}, ")
+	args.WriteString("wg *sync.WaitGroup, ")
+	args.WriteString("respCh chan proto.Message, ")
+	args.WriteString("errCh chan error")
+	args.WriteString(")")
+
+	g.P(g.ProxyFns, "func proxy"+generator.CamelCase(method.GetName())+args.String()+"{")
+	g.P(g.ProxyFns, "defer wg.Done()")
+	g.P(g.ProxyFns, "resp, err := client.Conn."+method.GetName()+"(client.Context, in.(*"+g.typeName(method.GetInputType())+"))")
+	g.P(g.ProxyFns, "if err != nil {")
+	g.P(g.ProxyFns, "errCh<-err")
+	g.P(g.ProxyFns, "return")
+	g.P(g.ProxyFns, "}")
+	// TODO: See if we can better abstract this
+	g.P(g.ProxyFns, "resp.Response[0].Metadata = &NodeMetadata{Hostname: client.Target}")
+	g.P(g.ProxyFns, "respCh<-resp")
+	g.P(g.ProxyFns, "}")
+	g.P(g.ProxyFns, "")
+}
+
+// generateServiceRunner is the function that handles the client calls and response
+// aggregation.
+func (g *proxy) generateServiceRunner(serviceName string) {
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("clients []*proxy" + serviceName + "Client, ")
+	args.WriteString("in interface{}, ")
+	args.WriteString("runner runner" + generator.CamelCase(serviceName+"_fn"))
+	args.WriteString(")")
+
+	var returns strings.Builder
+	returns.WriteString("(")
+	returns.WriteString("[]proto.Message, ")
+	returns.WriteString("error")
+	returns.WriteString(")")
+
+	g.P(g.ProxyFns, "func proxy"+generator.CamelCase(serviceName+"_runner")+args.String()+returns.String()+"{")
+	g.P(g.ProxyFns, "var (")
+	g.P(g.ProxyFns, "errors *go_multierror.Error")
+	g.P(g.ProxyFns, "wg sync.WaitGroup")
+	g.P(g.ProxyFns, ")")
+
+	g.P(g.ProxyFns, "respCh := make(chan proto.Message, len(clients))")
+	g.P(g.ProxyFns, "errCh := make(chan error, len(clients))")
+	g.P(g.ProxyFns, "wg.Add(len(clients))")
+
+	g.P(g.ProxyFns, "for _, client := range clients {")
+	g.P(g.ProxyFns, "go runner(client, in, &wg, respCh, errCh)")
+	g.P(g.ProxyFns, "}")
+
+	g.P(g.ProxyFns, "wg.Wait()")
+	g.P(g.ProxyFns, "close(respCh)")
+	g.P(g.ProxyFns, "close(errCh)")
+	g.P(g.ProxyFns, "")
+
+	g.P(g.ProxyFns, "var response []proto.Message")
+	g.P(g.ProxyFns, "for resp := range respCh {")
+	g.P(g.ProxyFns, "response = append(response, resp)")
+	g.P(g.ProxyFns, "}")
+
+	g.P(g.ProxyFns, "for err := range errCh {")
+	g.P(g.ProxyFns, "errors = go_multierror.Append(errors, err)")
+	g.P(g.ProxyFns, "}")
+
+	g.P(g.ProxyFns, "return response, errors.ErrorOrNil()")
+	g.P(g.ProxyFns, "}")
+	g.P(g.ProxyFns, "")
+}
+
+// generateClientFns generates the helper functions to instantiate a slice of service oriented client connections.
+func (g *proxy) generateClientFns(serviceName, pkgName string) {
+	fullServName := serviceName
+	if pkgName != "" {
+		fullServName = pkgName + "." + fullServName
+	}
+	g.P(g.Clients, "")
+	g.P(g.Clients, "func create"+serviceName+"Client(targets []string, creds credentials.TransportCredentials, proxyMd metadata.MD) ([]*proxy"+serviceName+"Client ,error){")
+	g.P(g.Clients, "var errors *go_multierror.Error")
+	g.P(g.Clients, "clients := make([]*proxy"+serviceName+"Client, 0, len(targets))")
+	g.P(g.Clients, "for _, target := range targets {")
+	g.P(g.Clients, "c := &proxy"+serviceName+"Client{")
+	g.P(g.Clients, "// TODO change the context to be more useful ( ex cancelable )")
+	g.P(g.Clients, "Context: metadata.NewOutgoingContext(context.Background(), proxyMd),")
+	g.P(g.Clients, "Target:  target,")
+	g.P(g.Clients, "}")
+	g.P(g.Clients, "// TODO: i think we potentially leak a client here,")
+	g.P(g.Clients, "// we should close the request // cancel the context if it errors")
+	g.P(g.Clients, "// Explicitly set OSD port")
+	g.P(g.Clients, "conn, err := grpc.Dial(fmt.Sprintf(\"%s:%d\", target, 50000), grpc.WithTransportCredentials(creds))")
+	g.P(g.Clients, "if err != nil {")
+	g.P(g.Clients, "// TODO: probably worth wrapping err to add some context about the target")
+	g.P(g.Clients, "errors = go_multierror.Append(errors, err)")
+	g.P(g.Clients, "continue")
+	g.P(g.Clients, "}")
+	g.P(g.Clients, "c.Conn = "+pkgName+".New"+serviceName+"Client(conn)")
+	g.P(g.Clients, "clients = append(clients, c)")
+	g.P(g.Clients, "}")
+	g.P(g.Clients, "return clients, errors.ErrorOrNil()")
+	g.P(g.Clients, "}")
+}


### PR DESCRIPTION
Example usage:

Given the following api.proto definition:

```protobuf
syntax = "proto3";

package apid;

option go_package = "gapi";

import public "api/os/os.proto";
import public "api/machine/machine.proto";
```

We can use the import statements to generate a consolidated view of all types/clients/methods
we need to support. The generated code follows a similar pattern to before --
- generate a runner function type
- generate a runner ( to actually invoke the given runner function )
- generate a massive switch statement to handle the routing
but now also generates a runner per service.

The code can be generated using something like:

```bash
protoc -I . --plugin=proxy --proxy_out=plugins=grpc+proxy:api/api api/api/api.proto`
```

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>