### PR TITLE
feat: Add support for streaming endpoints

### DIFF
--- a/pkg/proxy/interceptor.go
+++ b/pkg/proxy/interceptor.go
@@ -6,13 +6,13 @@ package proxy
 
 import "github.com/golang/protobuf/protoc-gen-go/generator"
 
-// generateProxyInterceptor is a method of the proxy struct that satisfies the
+// generateUnaryInterceptor is a method of the proxy struct that satisfies the
 // grpc.UnaryInterceptor interface. This allows us to make use of the tls
 // information from the provider to include it with each subsequent request
 // from the proxy. This is also where we handle some of the routing decisions,
 // namely being able to filter on the supported service and handling the
 // 'proxyfrom' metadata field to prevent infinite loops.
-func (g *proxy) generateProxyInterceptor(serviceName string) {
+func (g *proxy) generateUnaryInterceptor(serviceName string) {
 	tName := generator.CamelCase(serviceName + "_proxy")
 	g.gen.P("func (p *" + tName + ") UnaryInterceptor() grpc.UnaryServerInterceptor {")
 	g.gen.P("return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {")
@@ -33,7 +33,40 @@ func (g *proxy) generateProxyInterceptor(serviceName string) {
 	g.gen.P("  tls.WithCACertPEM(ca),")
 	g.gen.P("  tls.WithKeypair(*certs),")
 	g.gen.P(")")
-	g.gen.P("return p.Proxy(ctx, info.FullMethod, credentials.NewTLS(tlsConfig), req)")
+	g.gen.P("return p.UnaryProxy(ctx, info.FullMethod, credentials.NewTLS(tlsConfig), req)")
+	g.gen.P("}")
+	g.gen.P("}")
+	g.gen.P("")
+}
+
+// generateStreamInterceptor is a method of the proxy struct that satisfies the
+// grpc.UnaryInterceptor interface. This allows us to make use of the tls
+// information from the provider to include it with each subsequent request
+// from the proxy. This is also where we handle some of the routing decisions,
+// namely being able to filter on the supported service and handling the
+// 'proxyfrom' metadata field to prevent infinite loops.
+func (g *proxy) generateStreamInterceptor(serviceName string) {
+	tName := generator.CamelCase(serviceName + "_proxy")
+	g.gen.P("func (p *" + tName + ") StreamInterceptor() grpc.StreamServerInterceptor {")
+	g.gen.P("return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {")
+	g.gen.P("md, _ := metadata.FromIncomingContext(ss.Context())")
+	g.gen.P("if _, ok := md[\"proxyfrom\"]; ok {")
+	g.gen.P("return handler(srv, ss)")
+	g.gen.P("}")
+	g.gen.P("ca, err := p.Provider.GetCA()")
+	g.gen.P("if err != nil {")
+	g.gen.P("	return err")
+	g.gen.P("}")
+	g.gen.P("certs, err := p.Provider.GetCertificate(nil)")
+	g.gen.P("if err != nil {")
+	g.gen.P("  return err")
+	g.gen.P("}")
+	g.gen.P("tlsConfig, err := tls.New(")
+	g.gen.P("  tls.WithClientAuthType(tls.Mutual),")
+	g.gen.P("  tls.WithCACertPEM(ca),")
+	g.gen.P("  tls.WithKeypair(*certs),")
+	g.gen.P(")")
+	g.gen.P("return p.StreamProxy(ss, info.FullMethod, credentials.NewTLS(tlsConfig), srv)")
 	g.gen.P("}")
 	g.gen.P("}")
 	g.gen.P("")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -5,10 +5,8 @@
 package proxy
 
 import (
-	"fmt"
 	"strings"
 
-	pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
@@ -45,103 +43,6 @@ func (g *proxy) generateProxyStruct(serviceName string) {
 	g.gen.P("}")
 	g.gen.P("}")
 	g.gen.P("")
-}
-
-// generateProxyRouter creates the routing part of the proxy. That is it
-// enables us to map the incoming grpc method to the function/client call
-// so we can properly call the proper rpc endpoint.
-func (g *proxy) generateProxyRouter(serviceName string) {
-	// Leaving this in as left overs from grpc plugin, but not
-	// sure it really makes sense to keep it like this versus
-	// just calling the addimport call in Generate()
-	contextPkg = string(g.gen.AddImport(contextPkgPath))
-	grpcPkg = string(g.gen.AddImport(grpcPkgPath))
-
-	var args strings.Builder
-	args.WriteString("(")
-	args.WriteString("ctx " + contextPkg + ".Context, ")
-	args.WriteString("method string, ")
-	args.WriteString("creds credentials.TransportCredentials, ")
-	args.WriteString("in interface{}, ")
-	args.WriteString("opts ..." + grpcPkg + ".CallOption")
-	args.WriteString(")")
-
-	var returns strings.Builder
-	returns.WriteString("(")
-	returns.WriteString("proto.Message, ")
-	returns.WriteString("error")
-	returns.WriteString(")")
-
-	g.gen.P("func (p *" + generator.CamelCase(serviceName+"_proxy") + ") Proxy " + args.String() + returns.String() + "{")
-	g.gen.P("var (")
-	g.gen.P("err error")
-	g.gen.P("errors *go_multierror.Error")
-	g.gen.P("msgs []proto.Message")
-	g.gen.P("ok bool")
-	g.gen.P("response proto.Message")
-	g.gen.P("targets []string")
-	g.gen.P(")")
-
-	// Parse targets from incoming metadata/context
-	g.gen.P("md, _ := metadata.FromIncomingContext(ctx)")
-	g.gen.P("// default to target node specified in config or on cli")
-	g.gen.P("if targets, ok = md[\"targets\"]; !ok {")
-	g.gen.P("targets = md[\":authority\"]")
-	g.gen.P("}")
-
-	// Set up client connections
-	g.gen.P("proxyMd := metadata.New(make(map[string]string))")
-	g.gen.P("proxyMd.Set(\"proxyfrom\", md[\":authority\"]...)")
-	g.gen.P("")
-
-	// Handle routes
-	g.gen.P("switch method {")
-	g.gen.P(g.ProxySwitch.String())
-	g.gen.P("}")
-	g.gen.P("")
-	g.gen.P("if err != nil {")
-	g.gen.P("errors = go_multierror.Append(errors, err)")
-	g.gen.P("}")
-	g.gen.P("return response, errors.ErrorOrNil()")
-	g.gen.P("}")
-}
-
-func (g *proxy) generateSwitchStatement(serviceName, pkgName string, methods []*pb.MethodDescriptorProto) {
-	for _, method := range methods {
-		// No support for streaming stuff yet
-		if method.GetServerStreaming() || method.GetClientStreaming() {
-			continue
-		}
-		// skip support for deprecated methods
-		if method.GetOptions().GetDeprecated() {
-			continue
-		}
-		fullServName := serviceName
-		if pkgName != "" {
-			fullServName = pkgName + "." + fullServName
-		}
-		sname := fmt.Sprintf("/%s/%s", fullServName, method.GetName())
-		g.P(g.ProxySwitch, "case \""+sname+"\":")
-		g.P(g.ProxySwitch, "// Initialize target clients")
-		g.P(g.ProxySwitch, "clients, err := create"+serviceName+"Client(targets, creds, proxyMd)")
-		g.P(g.ProxySwitch, "if err != nil {")
-		g.P(g.ProxySwitch, "break")
-		g.P(g.ProxySwitch, "}")
-
-		var fnArgs strings.Builder
-		fnArgs.WriteString("(")
-		fnArgs.WriteString("clients, ")
-		fnArgs.WriteString("in, ")
-		fnArgs.WriteString("proxy" + generator.CamelCase(method.GetName()))
-		fnArgs.WriteString(")")
-
-		g.P(g.ProxySwitch, "resp := &"+g.typeName(method.GetOutputType())+"{}")
-		g.P(g.ProxySwitch, "msgs, err = proxy"+serviceName+"Runner"+fnArgs.String())
-		g.P(g.ProxySwitch, "for _, msg := range msgs {")
-		g.P(g.ProxySwitch, "resp.Response = append(resp.Response, msg.(*"+g.typeName(method.GetOutputType())+").Response[0])")
-		g.P(g.ProxySwitch, "}")
-		g.P(g.ProxySwitch, "response = resp")
-	}
 }
 
 func (g *proxy) generateStreamCopyHelper() {

--- a/pkg/proxy/streamproxy.go
+++ b/pkg/proxy/streamproxy.go
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package proxy
+
+import (
+	"fmt"
+	"strings"
+
+	pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
+)
+
+// generateStreamProxyRouter creates the routing part of the proxy. That is it
+// enables us to map the incoming grpc method to the function/client call
+// so we can properly call the proper rpc endpoint.
+func (g *proxy) generateStreamProxyRouter(serviceName string) {
+
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("ss " + grpcPkg + ".ServerStream, ")
+	args.WriteString("method string, ")
+	args.WriteString("creds credentials.TransportCredentials, ")
+	args.WriteString("srv interface{}, ")
+	args.WriteString("opts ..." + grpcPkg + ".CallOption")
+	args.WriteString(")")
+
+	var returns strings.Builder
+	returns.WriteString("error")
+
+	g.gen.P("func (p *" + generator.CamelCase(serviceName+"_proxy") + ") StreamProxy " + args.String() + returns.String() + "{")
+	g.gen.P("var (")
+	g.gen.P("err error")
+	g.gen.P("errors *go_multierror.Error")
+	g.gen.P("ok bool")
+	g.gen.P("targets []string")
+	g.gen.P(")")
+	g.gen.P("")
+
+	// Parse targets from incoming metadata/context
+	g.gen.P("md, _ := metadata.FromIncomingContext(ss.Context())")
+	g.gen.P("// default to target node specified in config or on cli")
+	g.gen.P("if targets, ok = md[\"targets\"]; !ok {")
+	g.gen.P("targets = md[\":authority\"]")
+	g.gen.P("}")
+	g.gen.P("// Can discuss more on how to handle merging multiple streams later")
+	g.gen.P("// but for now, ensure we only deal with a single target")
+	g.gen.P("if len(targets) > 1 {")
+	g.gen.P("targets = targets[:1]")
+	g.gen.P("}")
+	g.gen.P("")
+
+	// Set up client connections
+	g.gen.P("proxyMd := metadata.New(make(map[string]string))")
+	g.gen.P("proxyMd.Set(\"proxyfrom\", md[\":authority\"]...)")
+	g.gen.P("")
+
+	// Handle routes
+	g.gen.P("switch method {")
+	g.gen.P(g.StreamProxySwitch.String())
+	g.gen.P("}")
+	g.gen.P("")
+	g.gen.P("if err != nil {")
+	g.gen.P("errors = go_multierror.Append(errors, err)")
+	g.gen.P("}")
+	g.gen.P("return errors.ErrorOrNil()")
+	g.gen.P("}")
+}
+
+func (g *proxy) generateStreamSwitchStatement(serviceName, pkgName string, methods []*pb.MethodDescriptorProto) {
+	for _, method := range methods {
+		// Only handle streaming methods
+		switch {
+		case method.GetServerStreaming():
+		case method.GetClientStreaming():
+		default:
+			continue
+		}
+
+		// skip support for deprecated methods
+		if method.GetOptions().GetDeprecated() {
+			continue
+		}
+
+		fullServName := serviceName
+		if pkgName != "" {
+			fullServName = pkgName + "." + fullServName
+		}
+		sname := fmt.Sprintf("/%s/%s", fullServName, method.GetName())
+		g.P(g.StreamProxySwitch, "case \""+sname+"\":")
+		g.P(g.StreamProxySwitch, "// Initialize target clients")
+		g.P(g.StreamProxySwitch, "clients, err := create"+serviceName+"Client(targets, creds, proxyMd)")
+		g.P(g.StreamProxySwitch, "if err != nil {")
+		g.P(g.StreamProxySwitch, "break")
+		g.P(g.StreamProxySwitch, "}")
+
+		g.P(g.StreamProxySwitch, "m := new("+g.typeName(method.GetInputType())+")")
+		g.P(g.StreamProxySwitch, "if err := ss.RecvMsg(m); err != nil {")
+		g.P(g.StreamProxySwitch, "return err")
+		g.P(g.StreamProxySwitch, "}")
+
+		g.P(g.StreamProxySwitch, "// artificially limit this to only the first client/target until")
+		g.P(g.StreamProxySwitch, "// we get multi-stream stuff sorted")
+		//	g.P(g.StreamProxySwitch, "outgoingContext := metadata.NewOutgoingContext(ss.Context(), proxyMd)")
+		g.P(g.StreamProxySwitch, "clientStream, err := clients[0].Conn."+method.GetName()+"(clients[0].Context, m)")
+		g.P(g.StreamProxySwitch, "if err != nil {")
+		g.P(g.StreamProxySwitch, "return err")
+		g.P(g.StreamProxySwitch, "}")
+		g.P(g.StreamProxySwitch, "var msg "+g.typeName(method.GetOutputType()))
+		g.P(g.StreamProxySwitch, "return copyClientServer(&msg, clientStream, ss.(grpc.ServerStream))")
+
+		/*
+			var fnArgs strings.Builder
+			fnArgs.WriteString("(")
+			fnArgs.WriteString("clients, ")
+			fnArgs.WriteString("in, ")
+			fnArgs.WriteString("proxy" + generator.CamelCase(method.GetName()))
+			fnArgs.WriteString(")")
+
+			g.P(g.StreamProxySwitch, "resp := &"+g.typeName(method.GetOutputType())+"{}")
+			g.P(g.StreamProxySwitch, "msgs, err = proxy"+serviceName+"Runner"+fnArgs.String())
+			g.P(g.StreamProxySwitch, "for _, msg := range msgs {")
+			g.P(g.StreamProxySwitch, "resp.Response = append(resp.Response, msg.(*"+g.typeName(method.GetOutputType())+").Response[0])")
+			g.P(g.StreamProxySwitch, "}")
+			g.P(g.StreamProxySwitch, "response = resp")
+		*/
+	}
+}

--- a/pkg/proxy/unaryproxy.go
+++ b/pkg/proxy/unaryproxy.go
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package proxy
+
+import (
+	"fmt"
+	"strings"
+
+	pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
+)
+
+// generateUnaryProxyRouter creates the routing part of the proxy. That is it
+// enables us to map the incoming grpc method to the function/client call
+// so we can properly call the proper rpc endpoint.
+func (g *proxy) generateUnaryProxyRouter(serviceName string) {
+	// Leaving this in as left overs from grpc plugin, but not
+	// sure it really makes sense to keep it like this versus
+	// just calling the addimport call in Generate()
+	contextPkg = string(g.gen.AddImport(contextPkgPath))
+	grpcPkg = string(g.gen.AddImport(grpcPkgPath))
+
+	var args strings.Builder
+	args.WriteString("(")
+	args.WriteString("ctx " + contextPkg + ".Context, ")
+	args.WriteString("method string, ")
+	args.WriteString("creds credentials.TransportCredentials, ")
+	args.WriteString("in interface{}, ")
+	args.WriteString("opts ..." + grpcPkg + ".CallOption")
+	args.WriteString(")")
+
+	var returns strings.Builder
+	returns.WriteString("(")
+	returns.WriteString("proto.Message, ")
+	returns.WriteString("error")
+	returns.WriteString(")")
+
+	g.gen.P("func (p *" + generator.CamelCase(serviceName+"_proxy") + ") UnaryProxy " + args.String() + returns.String() + "{")
+	g.gen.P("var (")
+	g.gen.P("err error")
+	g.gen.P("errors *go_multierror.Error")
+	g.gen.P("msgs []proto.Message")
+	g.gen.P("ok bool")
+	g.gen.P("response proto.Message")
+	g.gen.P("targets []string")
+	g.gen.P(")")
+
+	// Parse targets from incoming metadata/context
+	g.gen.P("md, _ := metadata.FromIncomingContext(ctx)")
+	g.gen.P("// default to target node specified in config or on cli")
+	g.gen.P("if targets, ok = md[\"targets\"]; !ok {")
+	g.gen.P("targets = md[\":authority\"]")
+	g.gen.P("}")
+
+	// Set up client connections
+	g.gen.P("proxyMd := metadata.New(make(map[string]string))")
+	g.gen.P("proxyMd.Set(\"proxyfrom\", md[\":authority\"]...)")
+	g.gen.P("")
+
+	// Handle routes
+	g.gen.P("switch method {")
+	g.gen.P(g.ProxySwitch.String())
+	g.gen.P("}")
+	g.gen.P("")
+	g.gen.P("if err != nil {")
+	g.gen.P("errors = go_multierror.Append(errors, err)")
+	g.gen.P("}")
+	g.gen.P("return response, errors.ErrorOrNil()")
+	g.gen.P("}")
+}
+
+func (g *proxy) generateUnarySwitchStatement(serviceName, pkgName string, methods []*pb.MethodDescriptorProto) {
+	for _, method := range methods {
+		if method.GetServerStreaming() || method.GetClientStreaming() {
+			continue
+		}
+		// skip support for deprecated methods
+		if method.GetOptions().GetDeprecated() {
+			continue
+		}
+		fullServName := serviceName
+		if pkgName != "" {
+			fullServName = pkgName + "." + fullServName
+		}
+		sname := fmt.Sprintf("/%s/%s", fullServName, method.GetName())
+		g.P(g.ProxySwitch, "case \""+sname+"\":")
+		g.P(g.ProxySwitch, "// Initialize target clients")
+		g.P(g.ProxySwitch, "clients, err := create"+serviceName+"Client(targets, creds, proxyMd)")
+		g.P(g.ProxySwitch, "if err != nil {")
+		g.P(g.ProxySwitch, "break")
+		g.P(g.ProxySwitch, "}")
+
+		var fnArgs strings.Builder
+		fnArgs.WriteString("(")
+		fnArgs.WriteString("clients, ")
+		fnArgs.WriteString("in, ")
+		fnArgs.WriteString("proxy" + generator.CamelCase(method.GetName()))
+		fnArgs.WriteString(")")
+
+		g.P(g.ProxySwitch, "resp := &"+g.typeName(method.GetOutputType())+"{}")
+		g.P(g.ProxySwitch, "msgs, err = proxy"+serviceName+"Runner"+fnArgs.String())
+		g.P(g.ProxySwitch, "for _, msg := range msgs {")
+		g.P(g.ProxySwitch, "resp.Response = append(resp.Response, msg.(*"+g.typeName(method.GetOutputType())+").Response[0])")
+		g.P(g.ProxySwitch, "}")
+		g.P(g.ProxySwitch, "response = resp")
+	}
+}


### PR DESCRIPTION
This introduces the ability to proxy streaming requests. We artificially limit
it to only the first target defined while we work out the nuances of
multitarget support.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>